### PR TITLE
Define raw_input() for Python 3

### DIFF
--- a/michi.py
+++ b/michi.py
@@ -37,6 +37,10 @@ import re
 import sys
 import time
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 # Given a board of size NxN (N=9, 19, ...), we represent the position
 # as an (N+1)*(N+2) string, with '.' (empty), 'X' (to-play player),


### PR DESCRIPTION
raw_input() was removed from Python 3 in favor of input()